### PR TITLE
docs: update README for lightweight API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# Layerswap Node API Library
+# @layerswap/sdk
 
 [![NPM version](https://img.shields.io/npm/v/@layerswap/sdk.svg)](https://npmjs.org/package/@layerswap/sdk) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@layerswap/sdk)
 
-This library provides convenient access to the Layerswap REST API from server-side TypeScript or JavaScript.
+Lightweight TypeScript client for the [Layerswap API v2](https://docs.layerswap.io/integration/API). Zero dependencies, uses native `fetch`.
 
-The REST API documentation can be found on [layerswapapi.readme.io](https://layerswapapi.readme.io/). The full API of this library can be found in [api.md](api.md).
+## Features
 
-It is generated with [Stainless](https://www.stainlessapi.com/).
+- Zero production dependencies
+- Works on Node 18+, Deno, Bun, browsers, Cloudflare Workers
+- Full TypeScript types for all requests and responses
+- Covers all 14 Layerswap API v2 endpoints
+- ESM and CommonJS support
 
 ## Installation
 
@@ -14,321 +18,173 @@ It is generated with [Stainless](https://www.stainlessapi.com/).
 npm install @layerswap/sdk
 ```
 
-## Usage
+## Quick Start
 
-The full API of this library can be found in [api.md](api.md).
+```ts
+import { LayerSwapApi } from '@layerswap/sdk';
 
-<!-- prettier-ignore -->
-```js
-import Layerswap from '@layerswap/sdk';
-
-const client = new Layerswap({
-  apiKey: process.env['LAYERSWAP_API_KEY'], // This is the default and can be omitted
+const api = new LayerSwapApi({
+  apiKey: 'your-api-key',
 });
 
-async function main() {
-  const quote = await client.swaps.quote.retrieve({
-    amount: 123,
-    destination_network: 'ARBITRUM_MAINNET',
-    destination_token: 'ETH',
-    source_network: 'OPTIMISM_MAINNET',
-    source_token: 'ETH',
-  });
+// Get a quote
+const quote = await api.getQuote({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+  amount: 0.1,
+});
 
-  console.log(quote.data);
+console.log(quote.receive_amount); // 0.099...
+```
+
+## API Reference
+
+### Configuration
+
+```ts
+const api = new LayerSwapApi({
+  apiKey: 'your-api-key',       // required
+  baseUrl: 'https://api.layerswap.io', // optional, default shown
+});
+```
+
+### Route Discovery
+
+```ts
+// Get all available networks
+const networks = await api.getNetworks();
+const evmNetworks = await api.getNetworks({ networkTypes: ['evm'] });
+
+// Get source networks/tokens for a destination
+const sources = await api.getSources({
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+});
+
+// Get destination networks/tokens for a source
+const destinations = await api.getDestinations({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+});
+```
+
+### Quotes & Limits
+
+```ts
+// Get transfer limits
+const limits = await api.getLimits({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+  amount: 1,
+});
+console.log(limits.min_amount, limits.max_amount);
+
+// Get a quote
+const quote = await api.getQuote({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+  amount: 0.1,
+});
+console.log(quote.receive_amount, quote.total_fee);
+
+// Get detailed quote with routing info
+const detailed = await api.getDetailedQuote({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+  amount: 0.1,
+});
+```
+
+### Swap Lifecycle
+
+```ts
+// Create a swap
+const swap = await api.createSwap({
+  sourceNetwork: 'ETHEREUM_MAINNET',
+  sourceToken: 'ETH',
+  destinationNetwork: 'STARKNET_MAINNET',
+  destinationToken: 'ETH',
+  amount: 0.1,
+  destinationAddress: '0x...',
+});
+console.log(swap.swap.id, swap.deposit_actions);
+
+// Get swap details
+const details = await api.getSwap('swap-id');
+
+// Get swap by transaction hash
+const byTx = await api.getSwapByTransactionHash('0x...');
+
+// List swaps for an address
+const swaps = await api.getSwaps({ address: '0x...' });
+
+// Get deposit actions
+const actions = await api.getDepositActions('swap-id', '0xsourceAddress');
+
+// Speed up deposit detection
+await api.speedUpDeposit('swap-id', '0xtransactionHash');
+```
+
+### Status
+
+```ts
+// Health check
+await api.health();
+
+// Transaction status
+const status = await api.getTransactionStatus({
+  network: 'ETHEREUM_MAINNET',
+  transactionId: '0x...',
+});
+```
+
+## Error Handling
+
+All API errors throw `LayerSwapApiError` with `statusCode`, `errorCode`, and `message`:
+
+```ts
+import { LayerSwapApi, LayerSwapApiError } from '@layerswap/sdk';
+
+try {
+  await api.getQuote({ /* ... */ });
+} catch (err) {
+  if (err instanceof LayerSwapApiError) {
+    console.log(err.statusCode); // 400, 403, 404, etc.
+    console.log(err.errorCode);  // e.g. "BAD_REQUEST"
+    console.log(err.message);
+  }
 }
-
-main();
 ```
 
-### Request & Response types
+## Types
 
-This library includes TypeScript definitions for all request params and response fields. You may import and use them like so:
-
-<!-- prettier-ignore -->
-```ts
-import Layerswap from '@layerswap/sdk';
-
-const client = new Layerswap({
-  apiKey: process.env['LAYERSWAP_API_KEY'], // This is the default and can be omitted
-});
-
-async function main() {
-  const params: Layerswap.Swaps.QuoteRetrieveParams = {
-    amount: 0,
-    destination_network: 'destination_network',
-    destination_token: 'destination_token',
-    source_network: 'source_network',
-    source_token: 'source_token',
-  };
-  const quote: Layerswap.Swaps.QuoteRetrieveResponse = await client.swaps.quote.retrieve(params);
-}
-
-main();
-```
-
-Documentation for each method, request param, and response field are available in docstrings and will appear on hover in most modern editors.
-
-## Handling errors
-
-When the library is unable to connect to the API,
-or if the API returns a non-success status code (i.e., 4xx or 5xx response),
-a subclass of `APIError` will be thrown:
-
-<!-- prettier-ignore -->
-```ts
-async function main() {
-  const quote = await client.swaps.quote
-    .retrieve({
-      amount: 0,
-      destination_network: 'destination_network',
-      destination_token: 'destination_token',
-      source_network: 'source_network',
-      source_token: 'source_token',
-    })
-    .catch(async (err) => {
-      if (err instanceof Layerswap.APIError) {
-        console.log(err.status); // 400
-        console.log(err.name); // BadRequestError
-        console.log(err.headers); // {server: 'nginx', ...}
-      } else {
-        throw err;
-      }
-    });
-}
-
-main();
-```
-
-Error codes are as followed:
-
-| Status Code | Error Type                 |
-| ----------- | -------------------------- |
-| 400         | `BadRequestError`          |
-| 401         | `AuthenticationError`      |
-| 403         | `PermissionDeniedError`    |
-| 404         | `NotFoundError`            |
-| 422         | `UnprocessableEntityError` |
-| 429         | `RateLimitError`           |
-| >=500       | `InternalServerError`      |
-| N/A         | `APIConnectionError`       |
-
-### Retries
-
-Certain errors will be automatically retried 2 times by default, with a short exponential backoff.
-Connection errors (for example, due to a network connectivity problem), 408 Request Timeout, 409 Conflict,
-429 Rate Limit, and >=500 Internal errors will all be retried by default.
-
-You can use the `maxRetries` option to configure or disable this:
-
-<!-- prettier-ignore -->
-```js
-// Configure the default for all requests:
-const client = new Layerswap({
-  maxRetries: 0, // default is 2
-});
-
-// Or, configure per-request:
-await client.swaps.quote.retrieve({ amount: 0, destination_network: 'destination_network', destination_token: 'destination_token', source_network: 'source_network', source_token: 'source_token' }, {
-  maxRetries: 5,
-});
-```
-
-### Timeouts
-
-Requests time out after 1 minute by default. You can configure this with a `timeout` option:
-
-<!-- prettier-ignore -->
-```ts
-// Configure the default for all requests:
-const client = new Layerswap({
-  timeout: 20 * 1000, // 20 seconds (default is 1 minute)
-});
-
-// Override per-request:
-await client.swaps.quote.retrieve({ amount: 0, destination_network: 'destination_network', destination_token: 'destination_token', source_network: 'source_network', source_token: 'source_token' }, {
-  timeout: 5 * 1000,
-});
-```
-
-On timeout, an `APIConnectionTimeoutError` is thrown.
-
-Note that requests which time out will be [retried twice by default](#retries).
-
-## Advanced Usage
-
-### Accessing raw Response data (e.g., headers)
-
-The "raw" `Response` returned by `fetch()` can be accessed through the `.asResponse()` method on the `APIPromise` type that all methods return.
-
-You can also use the `.withResponse()` method to get the raw `Response` along with the parsed data.
-
-<!-- prettier-ignore -->
-```ts
-const client = new Layerswap();
-
-const response = await client.swaps.quote
-  .retrieve({
-    amount: 0,
-    destination_network: 'destination_network',
-    destination_token: 'destination_token',
-    source_network: 'source_network',
-    source_token: 'source_token',
-  })
-  .asResponse();
-console.log(response.headers.get('X-My-Header'));
-console.log(response.statusText); // access the underlying Response object
-
-const { data: quote, response: raw } = await client.swaps.quote
-  .retrieve({
-    amount: 0,
-    destination_network: 'destination_network',
-    destination_token: 'destination_token',
-    source_network: 'source_network',
-    source_token: 'source_token',
-  })
-  .withResponse();
-console.log(raw.headers.get('X-My-Header'));
-console.log(quote.data);
-```
-
-### Making custom/undocumented requests
-
-This library is typed for convenient access to the documented API. If you need to access undocumented
-endpoints, params, or response properties, the library can still be used.
-
-#### Undocumented endpoints
-
-To make requests to undocumented endpoints, you can use `client.get`, `client.post`, and other HTTP verbs.
-Options on the client, such as retries, will be respected when making these requests.
+All types are exported and available for use:
 
 ```ts
-await client.post('/some/path', {
-  body: { some_prop: 'foo' },
-  query: { some_query_arg: 'bar' },
-});
+import type {
+  LsNetwork,
+  LsToken,
+  LsRoute,
+  LsQuote,
+  LsSwap,
+  LsSwapResponse,
+  LsDepositAction,
+  LsLimits,
+  LsDetailedQuote,
+  LsTransactionStatus,
+  LayerSwapQuoteRequest,
+  LayerSwapCreateRequest,
+} from '@layerswap/sdk';
 ```
 
-#### Undocumented request params
+## License
 
-To make requests using undocumented parameters, you may use `// @ts-expect-error` on the undocumented
-parameter. This library doesn't validate at runtime that the request matches the type, so any extra values you
-send will be sent as-is.
-
-```ts
-client.foo.create({
-  foo: 'my_param',
-  bar: 12,
-  // @ts-expect-error baz is not yet public
-  baz: 'undocumented option',
-});
-```
-
-For requests with the `GET` verb, any extra params will be in the query, all other requests will send the
-extra param in the body.
-
-If you want to explicitly send an extra argument, you can do so with the `query`, `body`, and `headers` request
-options.
-
-#### Undocumented response properties
-
-To access undocumented response properties, you may access the response object with `// @ts-expect-error` on
-the response object, or cast the response object to the requisite type. Like the request params, we do not
-validate or strip extra properties from the response from the API.
-
-### Customizing the fetch client
-
-By default, this library uses `node-fetch` in Node, and expects a global `fetch` function in other environments.
-
-If you would prefer to use a global, web-standards-compliant `fetch` function even in a Node environment,
-(for example, if you are running Node with `--experimental-fetch` or using NextJS which polyfills with `undici`),
-add the following import before your first import `from "Layerswap"`:
-
-```ts
-// Tell TypeScript and the package to use the global web fetch instead of node-fetch.
-// Note, despite the name, this does not add any polyfills, but expects them to be provided if needed.
-import '@layerswap/sdk/shims/web';
-import Layerswap from '@layerswap/sdk';
-```
-
-To do the inverse, add `import "@layerswap/sdk/shims/node"` (which does import polyfills).
-This can also be useful if you are getting the wrong TypeScript types for `Response` ([more details](https://github.com/layerswap/layerswap-sdk/tree/main/src/_shims#readme)).
-
-### Logging and middleware
-
-You may also provide a custom `fetch` function when instantiating the client,
-which can be used to inspect or alter the `Request` or `Response` before/after each request:
-
-```ts
-import { fetch } from 'undici'; // as one example
-import Layerswap from '@layerswap/sdk';
-
-const client = new Layerswap({
-  fetch: async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
-    console.log('About to make a request', url, init);
-    const response = await fetch(url, init);
-    console.log('Got response', response);
-    return response;
-  },
-});
-```
-
-Note that if given a `DEBUG=true` environment variable, this library will log all requests and responses automatically.
-This is intended for debugging purposes only and may change in the future without notice.
-
-### Configuring an HTTP(S) Agent (e.g., for proxies)
-
-By default, this library uses a stable agent for all http/https requests to reuse TCP connections, eliminating many TCP & TLS handshakes and shaving around 100ms off most requests.
-
-If you would like to disable or customize this behavior, for example to use the API behind a proxy, you can pass an `httpAgent` which is used for all requests (be they http or https), for example:
-
-<!-- prettier-ignore -->
-```ts
-import http from 'http';
-import { HttpsProxyAgent } from 'https-proxy-agent';
-
-// Configure the default for all requests:
-const client = new Layerswap({
-  httpAgent: new HttpsProxyAgent(process.env.PROXY_URL),
-});
-
-// Override per-request:
-await client.swaps.quote.retrieve(
-  {
-    amount: 0,
-    destination_network: 'destination_network',
-    destination_token: 'destination_token',
-    source_network: 'source_network',
-    source_token: 'source_token',
-  },
-  {
-    httpAgent: new http.Agent({ keepAlive: false }),
-  },
-);
-```
-
-## Semantic versioning
-
-This package generally follows [SemVer](https://semver.org/spec/v2.0.0.html) conventions, though certain backwards-incompatible changes may be released as minor versions:
-
-1. Changes that only affect static types, without breaking runtime behavior.
-2. Changes to library internals which are technically public but not intended or documented for external use. _(Please open a GitHub issue to let us know if you are relying on such internals)_.
-3. Changes that we do not expect to impact the vast majority of users in practice.
-
-We take backwards-compatibility seriously and work hard to ensure you can rely on a smooth upgrade experience.
-
-We are keen for your feedback; please open an [issue](https://www.github.com/layerswap/layerswap-sdk/issues) with questions, bugs, or suggestions.
-
-## Requirements
-
-TypeScript >= 4.5 is supported.
-
-The following runtimes are supported:
-
-Note that React Native is not supported at this time.
-
-If you are interested in other runtime environments, please open or upvote an issue on GitHub.
-
-## Contributing
-
-See [the contributing documentation](./CONTRIBUTING.md).
+Apache-2.0


### PR DESCRIPTION
## Summary
- Replace outdated Stainless-generated README with documentation for the new `LayerSwapApi` client
- Covers all endpoints: route discovery, quotes/limits, swap lifecycle, status
- Documents error handling with `LayerSwapApiError`
- Lists all exported types

## Test plan
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)